### PR TITLE
Only apply specialized index for oplog behaviors on late MongoDB versions

### DIFF
--- a/jaraco/mongodb/helper.py
+++ b/jaraco/mongodb/helper.py
@@ -69,3 +69,15 @@ def connect_gridfs(uri, db=None):
         db or connect_db(uri),
         collection=get_collection(uri) or 'fs',
     )
+
+
+def server_version(conn):
+    """
+    >>> conn = getfixture('mongodb_instance').get_connection()
+    >>> ver = server_version(conn)
+    >>> len(ver)
+    3
+    >>> set(map(type, ver))
+    {<class 'int'>}
+    """
+    return tuple(map(int, conn.server_info()['version'].split('.')))

--- a/newsfragments/28.feature.1.rst
+++ b/newsfragments/28.feature.1.rst
@@ -1,0 +1,1 @@
+``oplog`` ``createIndexes`` support is now only applied on MongoDB 4.4 and later.

--- a/newsfragments/28.feature.rst
+++ b/newsfragments/28.feature.rst
@@ -1,0 +1,1 @@
+Added ``helpers.server_version``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
 	jaraco.collections>=2
 	importlib_metadata; python_version < "3.8"
 	autocommand
+	cachetools
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ testing =
 	# local
 	cherrypy
 	types-python-dateutil
+	types-cachetools
 
 docs =
 	# upstream


### PR DESCRIPTION
I'm pondering whether the oplog index handling should be applied to older server versions, so I created this change to explore the possibility of selectively applying that behavior.