### PR TITLE
Download and install MongoDB if not already available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
+      # needed to run mongodb
+      # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-ubuntu-tarball/
+      - uses: awalsh128/cache-apt-pkgs-action@latest
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        with:
+          packages: libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
       - name: Run
         run: tox
 

--- a/jaraco/mongodb/fixtures.py
+++ b/jaraco/mongodb/fixtures.py
@@ -49,6 +49,7 @@ def _ephemeral_instance(config):
             pymongo.MongoClient(instance.get_connect_hosts())
             yield instance
     except Exception as err:
+        raise
         pytest.skip(f"MongoDB not available ({err})")
     instance.stop()
 

--- a/jaraco/mongodb/fixtures.py
+++ b/jaraco/mongodb/fixtures.py
@@ -43,10 +43,11 @@ def _ephemeral_instance(config):
     params = shlex.split(params_raw)
     try:
         instance = service.MongoDBInstance()
-        instance.merge_mongod_args(params)
-        instance.start()
-        pymongo.MongoClient(instance.get_connect_hosts())
-        yield instance
+        with instance.ensure():
+            instance.merge_mongod_args(params)
+            instance.start()
+            pymongo.MongoClient(instance.get_connect_hosts())
+            yield instance
     except Exception as err:
         pytest.skip(f"MongoDB not available ({err})")
     instance.stop()

--- a/jaraco/mongodb/install.py
+++ b/jaraco/mongodb/install.py
@@ -1,0 +1,37 @@
+import json
+import re
+import platform
+
+import requests
+
+
+def get_download_url():
+    html = requests.get('https://www.mongodb.com/try/download/community').text
+    server_data = re.search(
+        r'<script id="server-data">\s*window\.__serverData=(.*?)\s*</script>',
+        html,
+        flags=re.DOTALL | re.MULTILINE,
+    ).group(1)
+    data = json.loads(server_data)
+    versions = data['components'][2]['props']['embeddedComponents'][0]['props'][
+        'items'
+    ][2]['embeddedComponents'][0]['props']['data'][0]['data'][0]
+    best_version = next(ver for ver in versions if versions[ver]['meta']['current'])
+    platforms = versions[best_version]['platforms']
+    lookup = {
+        ('Darwin', 'arm64'): 'macOS ARM 64',
+        ('Darwin', 'x86_64'): 'macOS x64',
+        ('Linux', 'x86_64'): 'Ubuntu 22.04 x64',
+        ('Linux', 'aarch64'): 'Ubuntu 22.04 ARM 64',
+        ('Windows', 'x86_64'): 'Windows x64',
+        ('Windows', 'ARM64'): 'Windows x64',
+    }
+    plat_name = lookup[(platform.system(), platform.machine())]
+    return platforms[plat_name]['tgz']
+
+
+def install():
+    print(get_download_url())
+
+
+__name__ == '__main__' and install()

--- a/jaraco/mongodb/install.py
+++ b/jaraco/mongodb/install.py
@@ -1,12 +1,17 @@
 import json
-import re
+import pathlib
 import platform
+import re
+import tarfile
+import urllib.request
 
-import requests
+import autocommand
 
 
 def get_download_url():
-    html = requests.get('https://www.mongodb.com/try/download/community').text
+    source = 'https://www.mongodb.com/try/download/community'
+    with urllib.request.urlopen(source) as resp:
+        html = resp.read().decode('utf-8')
     server_data = re.search(
         r'<script id="server-data">\s*window\.__serverData=(.*?)\s*</script>',
         html,
@@ -30,8 +35,9 @@ def get_download_url():
     return platforms[plat_name]['tgz']
 
 
-def install():
-    print(get_download_url())
-
-
-__name__ == '__main__' and install()
+@autocommand.autocommand(__name__)
+def install(target: pathlib.Path = pathlib.Path()):
+    url = get_download_url()
+    with urllib.request.urlopen(url) as resp:
+        with tarfile.open(fileobj=resp, mode='r|*') as obj:
+            obj.extractall(target.expanduser())

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
 	pytimeparse
 	jaraco.collections>=2
 	importlib_metadata; python_version < "3.8"
-	requests
+	autocommand
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
 	pytimeparse
 	jaraco.collections>=2
 	importlib_metadata; python_version < "3.8"
+	requests
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
Since Github CI no longer supplies an installed MongoDB and since it's probably difficult to ensure that's the case across platforms, and because there doesn't appear to be a github action to help with this, just extend the plugin to download and utilize a temporary instance of MongoDB, but only if an existing version is not already available.