### PR TITLE
Fix timeouts starting the server on Windows under GHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,8 @@ env:
     PY_COLORS
     PYTEST_THEME
     PYTEST_THEME_MODE
+    GITHUB_*
+    RUNNER_*
 
   # Suppress noisy pip warnings
   PIP_DISABLE_PIP_VERSION_CHECK: 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,6 @@ jobs:
           platform: ubuntu-latest
         - python: pypy3.9
           platform: ubuntu-latest
-        exclude:
-        # Windows tests disabled due to #32
-        - platform: windows-latest
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.12' }}
     steps:

--- a/newsfragments/+32.bugfix.rst
+++ b/newsfragments/+32.bugfix.rst
@@ -1,0 +1,1 @@
+Extended the timeout dramatically on Windows, but only when GITHUB_ACTIONS is configured.

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 deps =
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
+passenv =
+	GITHUB_*
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
- Revert "Disable tests on Windows. Ref #32"
- Extend timeout more

Closes #32
